### PR TITLE
Fixed error when running postinstall on OS3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "grunt unit",
     "debug": "grunt serve",
     "start": "node application.js",
-    "postinstall": "scripts/postinstall.sh"
+    "postinstall": "chmod +x scripts/postinstall.sh && scripts/postinstall.sh"
   },
   "license": "mit"
 }


### PR DESCRIPTION
### Motivation
Fixed error below:
```
E0719 12:23:05.207790 1 util.go:91] npm info postinstall barcode-reader-service@0.2.1 

> barcode-reader-service@0.2.1 postinstall /opt/app-root/src 
> scripts/postinstall.sh 

E0719 12:23:05.216154 1 util.go:91] sh: scripts/postinstall.sh: Permission denied 
E0719 12:23:05.218803 1 util.go:91] 
E0719 12:23:05.262345 1 util.go:91] npm info barcode-reader-service@0.2.1 Failed to exec postinstall script 
E0719 12:23:05.262552 1 util.go:91] npm ERR! Linux 3.10.0-327.18.2.el7.x86_64 
E0719 12:23:05.262570 1 util.go:91] npm ERR! argv "node" "/opt/rh/nodejs010/root/usr/bin/npm" "install" "-d" 
E0719 12:23:05.262588 1 util.go:91] npm ERR! node v0.10.40 
E0719 12:23:05.263970 1 util.go:91] npm ERR! npm v2.14.13 
E0719 12:23:05.263988 1 util.go:91] npm ERR! code ELIFECYCLE 
E0719 12:23:05.263995 1 util.go:91] npm ERR! barcode-reader-service@0.2.1 postinstall: `scripts/postinstall.sh` 
E0719 12:23:05.264000 1 util.go:91] npm ERR! Exit status 126 
E0719 12:23:05.264007 1 util.go:91] npm ERR! 
E0719 12:23:05.264011 1 util.go:91] npm ERR! Failed at the barcode-reader-service@0.2.1 postinstall script 'scripts/postinstall.sh'. 
 E0719 12:23:05.264015 1 util.go:91] npm ERR! This is most likely a problem with the barcode-reader-service package, 
E0719 12:23:05.264018 1 util.go:91] npm ERR! not with npm itself. 
E0719 12:23:05.264021 1 util.go:91] npm ERR! Tell the author that this fails on your system: 
E0719 12:23:05.264025 1 util.go:91] npm ERR! scripts/postinstall.sh 
E0719 12:23:05.264028 1 util.go:91] npm ERR! You can get their info via: 
E0719 12:23:05.264031 1 util.go:91] npm ERR! npm owner ls barcode-reader-service 
E0719 12:23:05.264034 1 util.go:91] npm ERR! There is likely additional logging output above. 
E0719 12:23:05.265582 1 util.go:91] 
E0719 12:23:05.265621 1 util.go:91] npm ERR! Please include the following file with any support request: 
E0719 12:23:05.265628 1 util.go:91] npm ERR! /opt/app-root/src/npm-debug.log 
I0719 12:23:07.687107 1 cleanup.go:23] Removing temporary directory /tmp/s2i-build306272207 
I0719 12:23:07.687132 1 fs.go:156] Removing directory '/tmp/s2i-build306272207' 
F0719 12:23:07.688876 1 builder.go:204] Error: build error: non-zero (13) exit code from registry.access.redhat.com/openshift3/nodejs-010-rhel7:latest 
 Try: 0. Ongoing build with phase: Running 
 Try: 1. Ongoing build with phase: Failed 
```
### Ping
@odra @matzew 