### PR TITLE
RHMAP-11292 - restricted to run on node v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
   - "4.4.3"
 sudo: false
 before_install:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This service looks up a barcode by UPC id. It connects with a SOAP service, takes a mixed SOAP and CSV response, and returns JSON back to the client, more effectively mobilising the service.
 
+# Requirements 
+
+Service would work only with node 4 and above. See package.json for more details. 
+
 # Group Barcode API
 
 # Recent Searches [/barcode/recent]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This service looks up a barcode by UPC id. It connects with a SOAP service, take
 
 # Requirements 
 
-Service would work only with node 4 and above. See package.json for more details. 
+The service will only work with node 4 and above. See package.json for more details. 
 
 # Group Barcode API
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,12 @@
     "csv": "^0.4.2",
     "express": "~4.0.0",
     "fh-mbaas-api": "6.0.1",
+    "jsdom": "^9.8.3",
     "request": "^2.40.0",
     "soap": "^0.8.0"
+  },
+  "engines": {
+    "node": ">= 4"
   },
   "devDependencies": {
     "grunt-concurrent": "latest",


### PR DESCRIPTION
## What was done

- Add an 'engine' config to the package.json of the barcode-reader service, and set it to node 4.
- Add jsdom to the package.json
- Update the readme to mention that this service will not work with node 0.10.